### PR TITLE
Android code validation for get-started and authentication docs

### DIFF
--- a/shared/video-sdk/authentication-workflow/project-implementation-uikit/android.mdx
+++ b/shared/video-sdk/authentication-workflow/project-implementation-uikit/android.mdx
@@ -8,7 +8,7 @@ To integrate authentication into an <Vpl k="CLIENT" /> using <Vg k="UIK" />:
 
     ``` java
     // The base URL to your token server.
-    private String serverUrl = "<Token Server URL>"; // For example, https://app-name.herokuapp.com"
+    private String serverUrl = "<Token Server URL>"; // For example, https://app-name.herokuapp.com
     ```
 
 2.  **Set the token URL for the AgoraVideoViewer**

--- a/shared/video-sdk/authentication-workflow/project-implementation/android.mdx
+++ b/shared/video-sdk/authentication-workflow/project-implementation/android.mdx
@@ -65,7 +65,7 @@
 
     ``` java
     private int tokenRole; // The token role
-    private String serverUrl = "<Token Server URL>"; // The base URL to your token server. For example, https://app-name.herokuapp.com"
+    private String serverUrl = "<Token Server URL>"; // The base URL to your token server. For example, https://app-name.herokuapp.com
     private int tokenExpireTime = 40; // Expire time in Seconds.
     private EditText editChannelName; // To read the channel name from the UI.
     ```
@@ -129,20 +129,37 @@
 
     In the `MainActivity` class, add the following `setToken` method:
 
+    <ProductWrapper product="video-calling">
     ``` java
     void setToken(String newValue) {
         token = newValue;
-        if (agoraEngine.getConnectionState() != RtcConnection.CONNECTION_STATE_TYPE.CONNECTION_STATE_CONNECTED) { // Join a channel
+        if (agoraEngine.getConnectionState() != 3) { // Join a channel
             ChannelMediaOptions options = new ChannelMediaOptions();
-     <ProductWrapper product="video-calling">
+
             // For a Video call, set the channel profile as COMMUNICATION.
             options.channelProfile = Constants.CHANNEL_PROFILE_COMMUNICATION;
             // Set the client role as BROADCASTER or AUDIENCE according to the scenario.
             options.clientRoleType = Constants.CLIENT_ROLE_BROADCASTER;
             // Start local preview.
             agoraEngine.startPreview();
+
+            // Join the channel with a token.
+            agoraEngine.joinChannel(token, channelName, uid, options);
+        } else { // Already joined, renew the token by calling renewToken
+            agoraEngine.renewToken(token);
+            showMessage("Token renewed");
+        }
+    }
+    ```
     </ProductWrapper>
+
     <ProductWrapper product="interactive-live-streaming">
+    ``` java
+    void setToken(String newValue) {
+        token = newValue;
+        if (agoraEngine.getConnectionState() != 3) { // Join a channel
+            ChannelMediaOptions options = new ChannelMediaOptions();
+
             // For Live Streaming, set the channel profile as LIVE_BROADCASTING.
             options.channelProfile = Constants.CHANNEL_PROFILE_LIVE_BROADCASTING;
             // Set the client role as BROADCASTER or AUDIENCE according to the scenario.
@@ -153,7 +170,7 @@
                 // Start local preview.
                 agoraEngine.startPreview();
             }
-    </ProductWrapper>
+
             // Join the channel with a token.
             agoraEngine.joinChannel(token, channelName, uid, options);
         } else { // Already joined, renew the token by calling renewToken
@@ -162,6 +179,7 @@
         }
     }
     ```
+    </ProductWrapper>
 
 9.  **Handle the event triggered by <Vg k="AGORA_BACKEND" /> when the token is about to expire**
 
@@ -183,6 +201,7 @@
 
     In the `MainActivity` class, replace the `joinChannel` method, with the following:
 
+    <ProductWrapper product="video-calling">
     ``` java
     public void joinChannel(View view) {
         channelName = editChannelName.getText().toString();
@@ -195,13 +214,32 @@
         }
 
         if (checkSelfPermission()) {
-     <ProductWrapper product="video-calling">
             tokenRole = Constants.CLIENT_ROLE_BROADCASTER;
             // Display LocalSurfaceView.
             setupLocalVideo();
-            localSurfaceView.setVisibility(View.VISIBLE);
+            localSurfaceView.setVisibility(View.VISIBLE);    
+            isJoined = true;
+            fetchToken(uid, channelName, tokenRole);
+        } else {
+            showMessage("Permissions was not granted");
+        }
+    }
+    ```
     </ProductWrapper>
+
     <ProductWrapper product="interactive-live-streaming">
+    ``` java
+    public void joinChannel(View view) {
+        channelName = editChannelName.getText().toString();
+        if (channelName.length() == 0) {
+            showMessage("Type a channel name");
+            return;
+        } else if (!serverUrl.contains("http")) {
+            showMessage("Invalid token server URL");
+            return;
+        }
+
+        if (checkSelfPermission()) {
             if (audienceRole.isChecked()) { //Audience
                 tokenRole = Constants.CLIENT_ROLE_AUDIENCE;
             } else { //Host
@@ -211,7 +249,6 @@
                 localSurfaceView.setVisibility(View.VISIBLE);
             }
             audienceRole.setEnabled(false); // Disable the switch
-    </ProductWrapper>
             isJoined = true;
             fetchToken(uid, channelName, tokenRole);
         } else {
@@ -219,4 +256,6 @@
         }
     }
     ```
+    </ProductWrapper>
+    
 </PlatformWrapper>

--- a/shared/video-sdk/develop/ensure-channel-quality/project-implementation/android.mdx
+++ b/shared/video-sdk/develop/ensure-channel-quality/project-implementation/android.mdx
@@ -113,7 +113,7 @@ To implement the call quality features, take the following steps:
     // Enable the dual stream mode
     agoraEngine.enableDualStreamMode(true);
     // Set audio profile and audio scenario.
-    agoraEngine.setAudioProfile(Constants.AUDIO_PROFILE_DEFAULT, Constants.AUDIO_SCENARIO_HIGH_DEFINITION);
+    agoraEngine.setAudioProfile(Constants.AUDIO_PROFILE_DEFAULT, Constants.AUDIO_SCENARIO_CHATROOM);
 
     // Set the video profile
     VideoEncoderConfiguration videoConfig = new VideoEncoderConfiguration();

--- a/shared/video-sdk/get-started/get-started-sdk/project-implementation/android.mdx
+++ b/shared/video-sdk/get-started/get-started-sdk/project-implementation/android.mdx
@@ -252,7 +252,6 @@ To implement this logic, take the following steps:
         private int uid = 0;
         private boolean isJoined = false;
 
-        //  <Vg k="ENGINE" /> instance
         private RtcEngine agoraEngine;
         //SurfaceView to render local video in a Container.
         private SurfaceView localSurfaceView;
@@ -273,7 +272,6 @@ To implement this logic, take the following steps:
         private int uid = 0;
         private boolean isJoined = false;
 
-        //  <Vg k="ENGINE" /> instance
         private RtcEngine agoraEngine;
         //SurfaceView to render local video in a Container.
         private SurfaceView localSurfaceView;
@@ -314,9 +312,7 @@ To implement this logic, take the following steps:
                 // Listen for the remote host joining the channel to get the uid of the host.
                 public void onUserJoined(int uid, int elapsed) {
                 showMessage("Remote user joined " + uid);
-                  <ProductWrapper product="interactive-live-streaming">
-                if (!audienceRole.isChecked()) return;
-                </ProductWrapper>
+
                 // Set the remote video view
                 runOnUiThread(() -> setupRemoteVideo(uid));
             }

--- a/shared/video-sdk/get-started/get-started-sdk/project-test/android.mdx
+++ b/shared/video-sdk/get-started/get-started-sdk/project-test/android.mdx
@@ -11,11 +11,10 @@
     6. Select an option and click **Join** to start a session.
           - When you join as a **Host**, the local video is published and played in the <Vpl k="CLIENT"/>.
           - When you join as **Audience**, the remote stream is subscribed and played.
-</ProductWrapper>
+  </ProductWrapper>
 
 <ProductWrapper product="video-calling">
     6. Click **Join** to start a call. Now, you can see yourself on the device screen and talk to the remote user using your <Vpl k="CLIENT"/>.
 </ProductWrapper>
 
-        If this is the first time you run the project, you need to grant microphone and camera access to your <Vpl k="CLIENT"/>.
 </PlatformWrapper>


### PR DESCRIPTION
Tested the Android code in the following docs today:
Get-started SDK (Video calling + ILS)
Get-started Uikit (Video calling + ILS)
Authentication with VSDK (Video calling + ILS)
Authentication with UIkit (produces the same error we reported earlier even with the latest release)

Found some problems and fixed them. There were certain cases of ProductWrapper tags inside the code. The authentication code was broken due to a change in the SDK. Some conditional text fixes.