### PR TITLE
Add notAllowed for web

### DIFF
--- a/shared/voice-sdk/develop/_stream-raw-audio.mdx
+++ b/shared/voice-sdk/develop/_stream-raw-audio.mdx
@@ -36,11 +36,13 @@ When a user captures video and audio data, the data is available to the <Vpl k="
 
 ## Test your implementation
 
+<PlatformWrapper notAllowed="web">
 To ensure that you have implemented raw data processing into your <Vpl k="CLIENT" />:
 
 1. [Generate a temporary token](../reference/manage-agora-account#generate-a-temporary-token) in <Vg k="CONSOLE" /> .
 
 2. In your browser, navigate to the [<Vg k="COMPANY" /> web demo](https://webdemo.agora.io/agora-web-showcase/examples/Agora-Web-Tutorial-1to1-Web/) and update _App ID_, _Channel_, and _Token_ with the values for your temporary token, then click _Join_.
+</PlatformWrapper>
 
 <ProjectTest/>
 


### PR DESCRIPTION
The two steps under "Test your implementation" appear to be unnecessary for Web.