### PR TITLE
add channel encryption for ILS, Video and voice

### DIFF
--- a/shared/variables/global.js
+++ b/shared/variables/global.js
@@ -8,6 +8,8 @@ export const API_REF_OLD = 'https://docs.agora.io/en/Video/API%20Reference';
 export const API_REF_WEB_ROOT = `${API_REF_OLD}/web_ng`;
 export const API_REF_ANDROID_ROOT  = `${API_REF_ROOT}/java_ng/API`;
 export const API_REF_IOS_ROOT = `${API_REF_ROOT}/ios_ng/API`;
+export const API_REF_RN_ROOT  = `${API_REF_ROOT}/rn_ng/API`;
+export const API_REF_ROOT_VOICE = 'https://docs.agora.io/en/voice-call-4.x-beta/API%20Reference';
 
 export const CONSOLE = `${COMPANY} Console`;
 export const TOKEN = 'token';

--- a/shared/video-sdk/encrypt-media-streams/project-implementation/index.mdx
+++ b/shared/video-sdk/encrypt-media-streams/project-implementation/index.mdx
@@ -1,7 +1,9 @@
 import Android from './android.mdx';
 import Ios from './ios.mdx';
 import Web from './web.mdx';
+import ReactNative from './react-native.mdx'
 
 <Android />
 <Ios />
 <Web />
+<ReactNative />

--- a/shared/video-sdk/encrypt-media-streams/project-implementation/react-native.mdx
+++ b/shared/video-sdk/encrypt-media-streams/project-implementation/react-native.mdx
@@ -22,9 +22,9 @@
 
     To enable channel encryption in your <Vpl k="CLIENT" />, you need to:
 
-    1. Create an object of `EncryptionConfig` class and specify a configuration for the channel encryption. In the configuration, you specify `encryptionMode`, `encryptionKey`, and `encryptionKdfSalt`. `encryptionKdfSalt` is required for `Aes128Gcm2` and `Aes256Gcm2` modes but optional otherwise.
+    1. Create an `EncryptionConfig` instance and specify a configuration for the channel encryption. In the configuration, you specify `encryptionMode`, `encryptionKey`, and `encryptionKdfSalt`. `encryptionKdfSalt` is required for `Aes128Gcm2` and `Aes256Gcm2` modes, it is optional for other encryption modes.
 
-    2. Call `enableEncryption` and pass `true` and the `EncryptionConfig` object as parameters to enable media encryption.
+    2. To enable media encryption, call `enableEncryption` with your `EncryptionConfig` instance.
 
     To implement this logic, in `App.tsx`, add the following code after `agoraEngine.initialize({appId: appID});`
 
@@ -36,5 +36,5 @@
       };
     engine.enableEncryption(true, encryptionConfig);
     ```
-    <Vg k="COMPANY"/> recommends using `Aes128Gcm2` or `Aes256Gcm2` encrypted mode. These two modes support the use of salt for higher security.
+    Best practice is to use Aes128Gcm2 or Aes256Gcm2. These modes use salt for higher security.
 </PlatformWrapper>

--- a/shared/video-sdk/encrypt-media-streams/project-implementation/react-native.mdx
+++ b/shared/video-sdk/encrypt-media-streams/project-implementation/react-native.mdx
@@ -1,0 +1,40 @@
+<PlatformWrapper platform="react-native">
+1.  **Add the required variables**
+
+    In `App.tsx`, add the following to the declarations:
+
+    ```typescript
+    // In a production environment, you retrieve the key and salt from
+    // an authentication server. For this code example you generate locally.
+    const encryptionKey = '';
+    const encryptionSaltBase64 = '';
+    ```
+
+2.  **Import the required modules**
+
+    In `App.tsx`, add the following import in `import {} from 'react-native-agora-rtc-ng';`:
+
+    ```typescript
+    EncryptionMode,
+    ```
+
+3.  **Call the channel encryption method to enable channel encryption**
+
+    To enable channel encryption in your <Vpl k="CLIENT" />, you need to:
+
+    1. Create an object of `EncryptionConfig` class and specify a configuration for the channel encryption. In the configuration, you specify `encryptionMode`, `encryptionKey`, and `encryptionKdfSalt`. `encryptionKdfSalt` is required for `Aes128Gcm2` and `Aes256Gcm2` modes but optional otherwise.
+
+    2. Call `enableEncryption` and pass `true` and the `EncryptionConfig` object as parameters to enable media encryption.
+
+    To implement this logic, in `App.tsx`, add the following code after `agoraEngine.initialize({appId: appID});`
+
+    ```typescript
+    let encryptionConfig = {
+        encryptionBase64: encryptionBase64,
+        encryptionKey: encryptionKey,
+        encryptionMode: EncryptionMode.Aes128Ecb,
+      };
+    engine.enableEncryption(true, encryptionConfig);
+    ```
+    <Vg k="COMPANY"/> recommends using `Aes128Gcm2` or `Aes256Gcm2` encrypted mode. These two modes support the use of salt for higher security.
+</PlatformWrapper>

--- a/shared/video-sdk/encrypt-media-streams/project-setup/index.mdx
+++ b/shared/video-sdk/encrypt-media-streams/project-setup/index.mdx
@@ -1,7 +1,9 @@
 import Android from './android.mdx';
 import Ios from './ios.mdx';
 import Web from './web.mdx';
+import ReactNative from './react-native.mdx'
 
 <Android />
 <Ios />
 <Web />
+<ReactNative />

--- a/shared/video-sdk/encrypt-media-streams/project-setup/react-native.mdx
+++ b/shared/video-sdk/encrypt-media-streams/project-setup/react-native.mdx
@@ -1,0 +1,3 @@
+<PlatformWrapper platform="react-native">
+
+</PlatformWrapper>

--- a/shared/video-sdk/encrypt-media-streams/project-test/index.mdx
+++ b/shared/video-sdk/encrypt-media-streams/project-test/index.mdx
@@ -1,7 +1,9 @@
 import Android from './android.mdx';
 import Ios from './ios.mdx';
 import Web from './web.mdx';
+import ReactNative from './react-native.mdx'
 
 <Android />
 <Ios />
 <Web />
+<ReactNative />

--- a/shared/video-sdk/encrypt-media-streams/project-test/react-native.mdx
+++ b/shared/video-sdk/encrypt-media-streams/project-test/react-native.mdx
@@ -1,0 +1,10 @@
+- *Android*
+
+    1. Enable the Developer options on your Android device, and then connect it to your computer using a USB cable.
+    1. Run npx react-native run-android in the project root directory.
+
+- *iOS:*
+
+    1. Open the ProjectName/ios/ProjectName.xcworkspace folder with Xcode.
+    1. Connect your iOS device to your Mac using a USB cable.
+    1. Click the Build and run button in Xcode.

--- a/shared/video-sdk/encrypt-media-streams/project-test/react-native.mdx
+++ b/shared/video-sdk/encrypt-media-streams/project-test/react-native.mdx
@@ -1,10 +1,8 @@
 - *Android*
 
-    1. Enable the Developer options on your Android device, and then connect it to your computer using a USB cable.
+    1. Enable the Developer options on your Android device, and then connect it.
     1. Run npx react-native run-android in the project root directory.
 
 - *iOS:*
 
-    1. Open the ProjectName/ios/ProjectName.xcworkspace folder with Xcode.
-    1. Connect your iOS device to your Mac using a USB cable.
-    1. Click the Build and run button in Xcode.
+    1. In Xcode, run your project.

--- a/shared/video-sdk/encrypt-media-streams/reference/index.mdx
+++ b/shared/video-sdk/encrypt-media-streams/reference/index.mdx
@@ -1,7 +1,9 @@
 import Android from './android.mdx';
 import Ios from './ios.mdx';
 import Web from './web.mdx';
+import ReactNative from './react-native.mdx'
 
 <Android />
 <Ios />
 <Web />
+<ReactNative />

--- a/shared/video-sdk/encrypt-media-streams/reference/react-native.mdx
+++ b/shared/video-sdk/encrypt-media-streams/reference/react-native.mdx
@@ -1,0 +1,7 @@
+<PlatformWrapper platform="react-native">
+#### API references
+
+-   <Link target="_blank" to="{{global.API_REF_RN_ROOT}}/class_irtcengine.html#ariaid-title23">enableEncryption</Link>
+-   <Link target="_blank" to="{{global.API_REF_RN_ROOT}}/rtc_api_data_type.html#class_encryptionconfig">EncryptionConfig</Link>
+
+</PlatformWrapper>


### PR DESCRIPTION
Review these:
- http://localhost:3000/voice-calling/develop/media-stream-encryption?platform=react-native
- http://localhost:3000/video-calling/develop/media-stream-encryption?platform=react-native
- http://localhost:3000/interactive-live-streaming/develop/media-stream-encryption?platform=react-native

I have validated the code on android. Please note that the encryption modes `Aes128Gcm2` and `Aes256Gcm2` are returning -2 which is why I have used another encryption mode so that this sample code works as is.