### PR TITLE
Use token generator from web platform for react-native docs

### DIFF
--- a/shared/video-sdk/_integrate-token-generation.mdx
+++ b/shared/video-sdk/_integrate-token-generation.mdx
@@ -26,6 +26,8 @@ To follow this procedure you must have:
 
 Open your project in which you wish to integrate token generation.
 
+<ProjectSetup />
+
 ## Integrate token generation into your authentication system
 
 When a user sends an authentication request to your server, the server must check the user’s credentials against your internal security and business logic. If everything is in order, the server returns an <Vg k="COMPANY" /> authentication token to the <Vpl k="CLIENT" />. The <Vpl k="CLIENT" /> then uses this token to join a channel.

--- a/shared/video-sdk/_integrate-token-generation.mdx
+++ b/shared/video-sdk/_integrate-token-generation.mdx
@@ -18,9 +18,13 @@ When a user attempts to connect to an <Vg k="COMPANY" /> channel from your <Vpl 
 
 ## Prerequisites
 
+<PlatformWrapper notAllowed="react-native">
 To follow this procedure you must have:
-
 <Prerequites />
+</PlatformWrapper>
+<PlatformWrapper platform="react-native">
+To follow this procedure you must have an authentication server project in which you wish to integrate token generation.
+</PlatformWrapper>
 
 ## Project setup
 

--- a/shared/video-sdk/integrate-token-generation/project-implementation/react-native.mdx
+++ b/shared/video-sdk/integrate-token-generation/project-implementation/react-native.mdx
@@ -1,191 +1,49 @@
 <PlatformWrapper platform="react-native">
+        
+### Handle the system logic
 
-### **Get the App ID and App Certificate**
+1.  **Install the <Vg k="COMPANY" /> token builder dependency**
 
-1.  Get the [App ID](../reference/manage-agora-account#get-the-app-id) and the [App certificate](../reference/manage-agora-account#get-the-app-certificate) of your <Vg k="COMPANY" /> project.
+    To add the token generation methods, you need to add <Vg k="COMPANY" /> token generation code to your project. To add [Agora token builder package](https://github.com/AgoraIO/Tools/tree/master/DynamicKey/AgoraDynamicKey/nodejs) to your Node.js project, open your IDE terminal and run the following command:
 
-### **Deploy a token server**
-
-  Token generators create the tokens requested by your client app to enable secure access to Agora security infrastructure. To serve these tokens you deploy a generator in your security infrastructure. In order to show the authentication workflow, this section shows how to build and run a token server written in Golang on your local machine. This sample server uses the `BuildTokenWithUid` method.
-
-1.  Create a file, `server.go`, with the following content. Then replace `<Your App ID>` and `<Your App Certificate>` with your `App ID` and `App Certificate`.
-
-    ```go 
-    package main
-
-    import (
-        rtctokenbuilder "github.com/AgoraIO/Tools/DynamicKey/AgoraDynamicKey/go/src/rtctokenbuilder2"
-        "fmt"
-        "log"
-        "net/http"
-        "encoding/json"
-        "errors"
-        "strconv"
-    )
-
-    type rtc_int_token_struct struct{
-        Uid_rtc_int uint32 `json:"uid"`
-        Channel_name string `json:"ChannelName"`
-        Role uint32 `json:"role"`
-    }
-
-    var rtc_token string
-    var int_uid uint32
-    var channel_name string
-
-    var role_num uint32
-    var role rtctokenbuilder.Role
-
-    // Use RtcTokenBuilder to generate an RTC token.
-    func generateRtcToken(int_uid uint32, channelName string, role rtctokenbuilder.Role){
-
-        appID := "<Your App ID>"
-        appCertificate := "<Your App Certificate>"
-        // Number of seconds after which the AccessToken2 expires.
-        // When the AccessToken2 expires but the privilege does not expire, the user remains in the channel and can continue to publish streams. No callback is triggered from the SDK.
-        // However, once disconnected from the channel, the user cannot rejoin the channel with that token. Ensure the AccessToken2 does not expire before the privileges.
-        tokenExpireTimeInSeconds := uint32(40)
-        // Number of seconds after which the privilege expires.
-        // The token-privilege-will-expire callback occurs 30 seconds before the privilege expires.
-        // The token-privilege-did-expire callback occurs when the privilege expires.
-        // For demonstration purposes the expire time is set to 40 seconds. This shows you the automatic token renew actions of the client.
-        privilegeExpireTimeInSeconds := uint32(40)
-
-        result, err := rtctokenbuilder.BuildTokenWithUid(appID, appCertificate, channelName, int_uid, role, tokenExpireTimeInSeconds, privilegeExpireTimeInSeconds)
-        if err != nil {
-            fmt.Println(err)
-        } else {
-            fmt.Printf("Token with uid: %s\n", result)
-            fmt.Printf("uid is %d\n", int_uid )
-            fmt.Printf("ChannelName is %s\n", channelName)
-            fmt.Printf("Role is %d\n", role)
-        }
-        rtc_token = result
-    }
-
-
-    func rtcTokenHandler(w http.ResponseWriter, r *http.Request){
-        w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-        w.Header().Set("Access-Control-Allow-Origin", "*")
-        w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS");
-        w.Header().Set("Access-Control-Allow-Headers", "*");
-
-        if r.Method == "OPTIONS" {
-            w.WriteHeader(http.StatusOK)
-            return
-        }
-
-        if r.Method != "POST" && r.Method != "OPTIONS" {
-            http.Error(w, "Unsupported method. Please check.", http.StatusNotFound)
-            return
-        }
-
-
-        var t_int rtc_int_token_struct
-        var unmarshalErr *json.UnmarshalTypeError
-        int_decoder := json.NewDecoder(r.Body)
-        int_err := int_decoder.Decode(&t_int)
-        if (int_err == nil) {
-
-                    int_uid = t_int.Uid_rtc_int
-                    channel_name = t_int.Channel_name
-                    role_num = t_int.Role
-                    switch role_num {
-                        case 1:
-                            role = rtctokenbuilder.RolePublisher
-                        case 2:
-                            role = rtctokenbuilder.RoleSubscriber
-                    }
-        }
-        if (int_err != nil) {
-
-            if errors.As(int_err, &unmarshalErr){
-                    errorResponse(w, "Bad request. Wrong type provided for field " + unmarshalErr.Value  + unmarshalErr.Field + unmarshalErr.Struct, http.StatusBadRequest)
-                    } else {
-                    errorResponse(w, "Bad request.", http.StatusBadRequest)
-                }
-            return
-        }
-
-        generateRtcToken(int_uid, channel_name, role)
-        errorResponse(w, rtc_token, http.StatusOK)
-        log.Println(w, r)
-    }
-
-    func errorResponse(w http.ResponseWriter, message string, httpStatusCode int){
-        w.Header().Set("Content-Type", "application/json")
-        w.Header().Set("Access-Control-Allow-Origin", "*")
-        w.WriteHeader(httpStatusCode)
-        resp := make(map[string]string)
-        resp["token"] = message
-        resp["code"] = strconv.Itoa(httpStatusCode)
-        jsonResp, _ := json.Marshal(resp)
-        w.Write(jsonResp)
-
-    }
-
-    func main(){
-        // RTC token from RTC int uid
-        http.HandleFunc("/fetch_rtc_token", rtcTokenHandler)
-        fmt.Printf("Starting server at port 8082\n")
-
-        if err := http.ListenAndServe(":8082", nil); err != nil {
-            log.Fatal(err)
-        }
-    }
+    ``` bash
+    npm i agora-access-token
     ```
 
-1.  A `go.mod` file defines this module's import path and dependency requirements. To create the `go.mod` for your token server, run the following command:
+2.  **Import the <Vg k="COMPANY" /> token builder classes into your project**
 
-  ```bash
-  go mod init sampleServer
-  ```
+    To import the <Vg k="COMPANY" /> token builder classes into your project, add the following code at the beginning of the JavaScript source file where you wish to generate the authentication token:
 
-1.  Get dependencies by running the following command. You can use a Go mirror origin such as https://goproxy.cn/ to speed up the process.
-
-  ```bash
-  go mod tidy
-  ```
-
-1.  Start the server by running the following command:
-
-  ```bash
-  go run server.go
-  ```
-
-    This will start the server at `127.0.0.1:8082`.
+    ``` javascript
+    const {RtcTokenBuilder, RtmTokenBuilder, RtcRole, RtmRole} = require('agora-access-token')
+    ```
 
 ### **Implement token generation**
 
-1.  Make a POST request to your token server to dynamically fetch the token instead of hardcoding it. To do it, replace the `startCall()` method with the following code:
+<Vg k="AGORA_BACKEND" /> supports both integer user Ids and string user accounts for token generation. To ensure smooth communication, all the users in a channel must use the same type of Id, that is, either the integer `uid`, or a string `userAccount`. Depending on user type, you generate a token using either:
 
-    ``` typescript
-    startCall = async () => {
-      const {channelName} = this.state;
-      const response = await fetch('http://127.0.0.1:8082/fetch_rtc_token', {
-        method: 'POST',
-        body: JSON.stringify({
-          uid: 0,
-          channelName: channelName,
-          role: ClientRoleType.ClientRoleBroadcaster,
-        }),
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-        },
-      });
+-   `buildTokenWithUid` for an RTC token based on `uid`
 
-      if (!response.ok) {
-        console.log('error fetching token');
-      }
+-   `buildTokenWithAccount` for an RTC token based on `userAccount`
 
-      if (response.text !== null) {
-        // and further:
-        const asJSON = JSON.parse(response.text.toString()); // implicitly 'any', make sure to verify type on runtime.
-        this._engine?.joinChannelWithOptions(asJSON.data.token, channelName, 0, {
-          clientRoleType: ClientRoleType.ClientRoleBroadcaster,
-        });
-      }
-    };
-    ```
+To generate tokens based on user ID and user account, add the following code to the JavaScript source file where you wish to generate the authentication token:
 
+``` javascript
+const appId = '<Your app id>';
+const appCertificate = '<Your app certificate>';
+const channelName = '<Channel name>';
+const uid = 0;
+const userAccount = "User account";
+const role = RtcRole.PUBLISHER;
+const expirationTimeInSeconds = 3600
+const currentTimestamp = Math.floor(Date.now() / 1000)
+const privilegeExpiredTs = currentTimestamp + expirationTimeInSeconds
+// Build token with uid
+const tokenA = RtcTokenBuilder.buildTokenWithUid(appId, appCertificate, channelName, uid, role, privilegeExpiredTs);
+console.log("Token with integer number Uid: " + tokenA);
+
+// Build token with user account
+const tokenB = RtcTokenBuilder.buildTokenWithAccount(appId, appCertificate, channelName, userAccount, role, privilegeExpiredTs);
+console.log("Token with userAccount: " + tokenB);
+```
 </PlatformWrapper>

--- a/shared/video-sdk/integrate-token-generation/project-setup/react-native.mdx
+++ b/shared/video-sdk/integrate-token-generation/project-setup/react-native.mdx
@@ -2,6 +2,6 @@
 
 There are no methods available in the react-native SDK to generate authentication tokens. An easy workaround for this is to implement a token generator using `Node.js` libraries and host it on a server. Your <Vpl k="CLIENT" /> can make an HTTP get request to this server and fetch the token.
 
-This section will show you how to implement a token generator using Node.js.
+This section shows you how to implement a token generator using Node.js.
 
 </PlatformWrapper>

--- a/shared/video-sdk/integrate-token-generation/project-setup/react-native.mdx
+++ b/shared/video-sdk/integrate-token-generation/project-setup/react-native.mdx
@@ -1,3 +1,7 @@
 <PlatformWrapper platform="react-native">
 
+There are no methods available in the react-native SDK to generate authentication tokens. An easy workaround for this is to implement a token generator using `Node.js` libraries and host it on a server. Your <Vpl k="CLIENT" /> can make an HTTP get request to this server and fetch the token.
+
+This section will show you how to implement a token generator using Node.js.
+
 </PlatformWrapper>

--- a/shared/video-sdk/integrate-token-generation/project-test/react-native.mdx
+++ b/shared/video-sdk/integrate-token-generation/project-test/react-native.mdx
@@ -1,20 +1,26 @@
 <PlatformWrapper platform="react-native">
+        
+1.  In the sample code, set the variables `appId`, and `appCertificate` to values from <Vg k="CONSOLE" />.
 
-To ensure that you have implemented <Vpd k="PRODUCT" /> in your <Vpl k="CLIENT" />:
+2.  Set `channelName` and `expirationTimeInSeconds` to the name of the channel to join and the renew time for the token.
 
-1. [Generate a temporary token](../reference/manage-agora-account#generate-a-temporary-token) in <Vg k="CONSOLE" />.
+3.  For the purpose of this test, set `uid` equal to zero.
 
-2. In your browser, navigate to the <Link target="_blank" to="{{Global.DEMO_BASIC_VIDEO_CALL_URL}}"><Vg k="COMPANY" /> web demo</Link> and update _App ID_, _Channel_, and _Token_ with the values for your temporary token, then click **Join**.
+4.  Use the `node <file-name>.js` command to run your project.
 
-**To run the Android app on a physical device:**
+    The code generates two RTC tokens and prints them to the console. The first token is generated using an integer `uid` and the second token is generated using a `userAccount` string.
 
-    3. Enable the Developer options on your Android device, and then connect it to your computer using a USB cable.
-    1. Run npx react-native run-android in the project root directory.
+5.  Use the token to connect to a <Vpd k="NAME"/> channel.
 
-**To run the iOS app on a physical device:**
+    1.  In your browser, navigate to <Vg k="DEMO-PAGE-LINK" />.
 
-    3. Open the ProjectName/ios/ProjectName.xcworkspace folder with Xcode.
-    1. Connect your iOS device to your Mac using a USB cable.
-    1. Click the Build and run button in Xcode. 
+    2.  Fill in the *App ID*, and *Channel* with the same values that were used to call the RTC token generation method.
 
+    3.  Copy the RTC uid authentication token from the terminal and paste it into the demo page.
+
+    4.  Press **Join** to connect.
+
+        You see the local video on the screen.
+
+6.  Connect to the same channel from another device to confirm that everything works.
 </PlatformWrapper>


### PR DESCRIPTION
Since react-native SDK has no methods to generate tokens, we use the token generator docs from web platform.