### PR TITLE
Lots of things for keywords.

### DIFF
--- a/agora-chat/develop/authentication.mdx
+++ b/agora-chat/develop/authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Authenticate your users with tokens'
+title: 'Secure authentication with tokens'
 sidebar_position: 2
 type: docs
 description: >

--- a/agora-chat/get-started/get-started-sdk.mdx
+++ b/agora-chat/get-started/get-started-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'SDK quickstart'
-sidebar_position: 2
+sidebar_position: 1
 type: docs
 description: >
   A highly reliable global communication platform where users can chat one-to-one, in groups or in chat rooms.

--- a/agora-chat/get-started/get-started-uikit.mdx
+++ b/agora-chat/get-started/get-started-uikit.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'UI Samples quickstart'
-sidebar_position: 3
+sidebar_position: 2
 type: docs
 description: >
   A highly reliable global communication platform where users can chat one-to-one, in groups or in chat rooms.

--- a/cloud-recording/develop/authentication-workflow.mdx
+++ b/cloud-recording/develop/authentication-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Secure authentication'
+title: 'Secure authentication with tokens'
 sidebar_position: 3
 type: docs
 description: >

--- a/flexible-classroom/develop/authentication-workflow.mdx
+++ b/flexible-classroom/develop/authentication-workflow.mdx
@@ -1,9 +1,9 @@
 ---
-title: 'Authentication'
+title: 'Secure authentication with tokens'
 sidebar_position: 1
 type: docs
 description: >
-  Create an Signaling token server and a Signaling client app.
+  Create a Signaling token server and a Signaling client app.
 ---
 
 

--- a/interactive-live-streaming/develop/authentication-workflow.mdx
+++ b/interactive-live-streaming/develop/authentication-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Secure authentication'
+title: 'Secure authentication with tokens'
 sidebar_position: 2
 type: docs
 description: >

--- a/interactive-live-streaming/develop/product-workflow.mdx
+++ b/interactive-live-streaming/develop/product-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Screen share and volume control'
+title: 'Screen share, volume control and mute'
 sidebar_position: 5
 type: docs
 description: >

--- a/interactive-live-streaming/get-started/get-started-sdk.mdx
+++ b/interactive-live-streaming/get-started/get-started-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'SDK quickstart'
-sidebar_position: 2
+sidebar_position: 1
 type: docs
 description: >
   Rapidly develop and easily enhance your social, work, education and IoT apps with face-to-face interaction.

--- a/interactive-live-streaming/get-started/get-started-uikit.mdx
+++ b/interactive-live-streaming/get-started/get-started-uikit.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'UI Kit quickstart'
-sidebar_position: 1
+sidebar_position: 2
 type: docs
 description: >
   Rapidly develop and easily enhance your social, work, education and IoT apps with face-to-face interaction.

--- a/interactive-whiteboard/develop/authentication-workflow.md
+++ b/interactive-whiteboard/develop/authentication-workflow.md
@@ -1,5 +1,5 @@
 ---
-title: 'Secure authentication'
+title: 'Secure authentication with tokens'
 sidebar_position: 3
 type: docs
 description: >

--- a/interactive-whiteboard/get-started/get-started-sdk.mdx
+++ b/interactive-whiteboard/get-started/get-started-sdk.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Whiteboard quickstart'
-sidebar_position: 2
+title: 'SDK quickstart'
+sidebar_position: 1
 type: docs
 description: >
   Rapidly develop and easily enhance your social, work, education and IoT apps with face-to-face interaction.

--- a/interactive-whiteboard/get-started/get-started-uikit.mdx
+++ b/interactive-whiteboard/get-started/get-started-uikit.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Fastboard quickstart'
-sidebar_position: 1
+sidebar_position: 2
 type: docs
 description: >
   Rapidly develop and easily enhance your social, work, education, and IoT apps with face-to-face interaction.

--- a/on-premise-recording/develop/authentication-workflow.mdx
+++ b/on-premise-recording/develop/authentication-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Secure authentication'
+title: 'Secure authentication with tokens'
 sidebar_position: 1
 type: docs
 description: >

--- a/shared/video-sdk/develop/_ensure-channel-quality.mdx
+++ b/shared/video-sdk/develop/_ensure-channel-quality.mdx
@@ -172,6 +172,10 @@ The recommended settings for these different scenarios are:
 |960 x 720|15|1820|
 |960 x 720|30|2760|
 
+### Mirror mode
+
+By default, Video SDK does not mirror the video during encoding. You can use the `mirrorMode` parameter to decide whether to mirror the video that remote users see.
+
 ### Connection states
 
 When the connection state changes, Agora sends the `onConnectionStateChanged` callback. The following diagram illustrates the various states and how the states change as a client app joins and leaves a channel:

--- a/shared/video-sdk/develop/product-workflow/project-implementation/android.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/android.mdx
@@ -70,7 +70,7 @@ You see errors in your IDE. This is because this layout refers to methods that y
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     ```
 
-### Implement volume control and screen sharing logic
+### Implement screen sharing, volume control and mute
 
 To implement these features in your <Vpl k="CLIENT" />, take the following steps:
 

--- a/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
@@ -31,7 +31,7 @@ ElevatedButton(
 ),
 ```
 
-### Implement volume control and screen sharing logic
+### Implement screen sharing, volume control and mute
 
 To implement these features in your <Vpl k="CLIENT" />, take the following steps:
 

--- a/shared/video-sdk/develop/product-workflow/project-implementation/swift.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/swift.mdx
@@ -62,7 +62,7 @@ To create this user interface, in the `ViewController` class:
         |:---|:---|:---|
         | RPBroadcastProcessMode | String | RPBroadcastProcessModeSampleBuffer |
 
-### Implement volume control and screen sharing logic
+### Implement screen sharing, volume control and mute
 
 To implement these features in your <Vpl k="CLIENT" />, take the following steps:
 

--- a/shared/video-sdk/develop/product-workflow/project-implementation/unity.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/unity.mdx
@@ -32,7 +32,7 @@ In a real-world application, for each volume setting you want to control, you ty
     using TMPro;
     ```
 
-### Implement volume control and screen sharing logic
+### Implement screen sharing, volume control and mute
 
 To implement these features in your <Vpl k="CLIENT" />, take the following steps:
 

--- a/shared/video-sdk/develop/product-workflow/project-implementation/web.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/web.mdx
@@ -19,7 +19,7 @@ To create this UI, in `index.html`, add the following code after `<button type="
 <input type="range" min="0" id= "remoteAudioVolume" max="100" step="1">
 ```
 
-### Implement the <Vpd k="NAME"/> workflow
+### Implement autoplay blocking, screen sharing, volume control and mute
 
 To implement the <Vpd k="NAME"/> workflow logic in your <Vpl k="CLIENT" />, take the following steps:
 

--- a/shared/video-sdk/get-started/get-started-sdk/project-implementation/android.mdx
+++ b/shared/video-sdk/get-started/get-started-sdk/project-implementation/android.mdx
@@ -209,7 +209,7 @@ Import the necessary Android classes and handle the Android permissions.
     }
     ```
 
-### Implement the  <Vpd k="PRODUCT" /> logic
+### Implement the  channel logic
 
 The following figure shows the API call sequence of implementing  <Vpd k="PRODUCT" />.
 

--- a/shared/video-sdk/get-started/get-started-sdk/project-implementation/electron.mdx
+++ b/shared/video-sdk/get-started/get-started-sdk/project-implementation/electron.mdx
@@ -75,7 +75,7 @@ nodeIntegration: true,
 contextIsolation: false,
 ```
 
-### Implement the <Vpd k="PRODUCT" /> logic
+### Implement the channel logic
 
 The following figure shows the <Vpd k="PRODUCT" /> API call sequence.
 

--- a/shared/video-sdk/get-started/get-started-sdk/project-implementation/flutter.mdx
+++ b/shared/video-sdk/get-started/get-started-sdk/project-implementation/flutter.mdx
@@ -307,7 +307,7 @@ To implement this user interface, copy the following code into `_MyAppState` cla
 
     You see errors in your IDE. This is because this layout refers to methods that you create later.
 
-### Implement the <Vpd k="PRODUCT" /> logic
+### Implement the channel logic
 
 The following figure shows the API call sequence of implementing  <Vpd k="PRODUCT" />.
 

--- a/shared/video-sdk/get-started/get-started-sdk/project-implementation/react-native.mdx
+++ b/shared/video-sdk/get-started/get-started-sdk/project-implementation/react-native.mdx
@@ -282,7 +282,7 @@ return (
 ```
 </ProductWrapper>
 
-### Implement the <Vpd k="NAME"/> logic
+### Implement the channel logic
 
 When a user opens the <Vpl k="CLIENT" />, you initialize the <Vg k="ENGINE" />. When the user taps a button, the <Vpl k="CLIENT" /> joins or leaves a channel.
 

--- a/shared/video-sdk/get-started/get-started-sdk/project-implementation/unity.mdx
+++ b/shared/video-sdk/get-started/get-started-sdk/project-implementation/unity.mdx
@@ -124,7 +124,7 @@ Import the necessary .NET libraries, set up your <Vpl k="CLIENT" /> to run on An
 
     1. Click **Inspector**, you see that your script is added to **Canvas**.
 
-### Implement the <Vpd k="PRODUCT" /> logic
+### Implement the channel logic
 
 The following figure shows the API call sequence of implementing  <Vpd k="PRODUCT" />.
 

--- a/shared/video-sdk/get-started/get-started-sdk/project-implementation/web.mdx
+++ b/shared/video-sdk/get-started/get-started-sdk/project-implementation/web.mdx
@@ -62,7 +62,7 @@ This UI looks like:
 ![Interface](/images/video-sdk/quickstart_interface_ILS.png)
 </ProductWrapper>
 
-### Implement the <Vpd k="PRODUCT" /> logic
+### Implement the channel logic
 
 The following figure shows the    <Vpd k="PRODUCT" /> API call sequence.
 

--- a/shared/video-sdk/get-started/get-started-sdk/project-implementation/windows.mdx
+++ b/shared/video-sdk/get-started/get-started-sdk/project-implementation/windows.mdx
@@ -12,7 +12,7 @@ When you use the UI setting of the [sample project](https://github.com/AgoraIO/A
 
 ![](https://web-cdn.agora.io/docs-files/1568792708592)
 
-### Implement the  <Vpd k="PRODUCT" /> logic
+### Implement the  channel logic
 
 1. Initialize IRtcEngine
 

--- a/signaling/develop/authentication-workflow.mdx
+++ b/signaling/develop/authentication-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Authentication'
+title: 'Secure authentication with tokens'
 sidebar_position: 1
 type: docs
 description: >

--- a/signaling/overview/product-overview.mdx
+++ b/signaling/overview/product-overview.mdx
@@ -7,10 +7,10 @@ description: >
 
 
 <ProductOverview
-  title="Signaling"
+  title="Signaling (was RTM)"
   img="/images/signaling/signaling-overview.png"
-  quickStartLink="/signaling/get-started/get-started-sdk"
   apiReferenceLink="/api-reference"
+  quickStartLink="/signaling/get-started/get-started-sdk"
   samplesLink="https://github.com/AgoraIO/RTM"
   authenticationLink="/signaling/develop/authentication-workflow"
   productFeatures={[

--- a/video-calling/develop/authentication-workflow.mdx
+++ b/video-calling/develop/authentication-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Secure authentication'
+title: 'Secure authentication with tokens'
 sidebar_position: 3
 type: docs
 description: >

--- a/video-calling/develop/product-workflow.mdx
+++ b/video-calling/develop/product-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Screen share and volume control'
+title: 'Screen share, volume control and mute'
 sidebar_position: 6
 type: docs
 description: >

--- a/video-calling/get-started/get-started-sdk.mdx
+++ b/video-calling/get-started/get-started-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'SDK quickstart'
-sidebar_position: 2
+sidebar_position: 1
 type: docs
 description: >
   Rapidly develop and easily enhance your social, work, education and IoT apps with face-to-face interaction.

--- a/video-calling/get-started/get-started-uikit.mdx
+++ b/video-calling/get-started/get-started-uikit.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'UI Kit quickstart'
-sidebar_position: 1
+sidebar_position: 2
 type: docs
 description: >
   Rapidly develop and easily enhance your social, work, education and IoT apps with face-to-face interaction.

--- a/voice-calling/develop/authentication-workflow.mdx
+++ b/voice-calling/develop/authentication-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Secure authentication'
+title: 'Secure authentication with tokens'
 sidebar_position: 2
 type: docs
 description: >

--- a/voice-calling/develop/product-workflow.mdx
+++ b/voice-calling/develop/product-workflow.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Volume control'
+title: 'Volume control and mute'
 sidebar_position: 5
 type: docs
 description: >


### PR DESCRIPTION
Change are:

1| token | Change title to Secure authentication with tokens
-- | -- | --
2 | mute | Change title to Screen share, volume control and mute
3 | background | We have the Virtual Background page now
4 | recording | Product logic, should go to https://docs.agora.io/en/cloud-recording/overview/product-overview
5 | rtm | Added (was RTM) to overview page
6 | flutter | Button logic should help
7 | channel | Changed title to "Implement the channel logic" in the quickstart
8 | error | Tricky, the errors are now in the API ref
9 | audio | Page title logic, should go to Audio and voice effects page
10 | uid | Goes to core concepts, yay
11 | rtmp | API ref
12 | join | API ref
13 | mirror | Added to call quality doc
14 | screen share | Have the screen sharing page
15 | record | Should go to Cloud recording
16 | rtc | Does not really exist, this is Video SDK
17 | setClientRole | API ref
18 | virtual background | Have the Virtual background extension now: https://docs.agora.io/en/video-calling/develop/virtual-background
19 | chat | Product logic, should go to Agora Chat
20 | cloud recording | Product logic, should go to  Cloud Recording
21 | setVideoEncoderConfiguration | API Ref
22 | video | Product logic, should go to Video Calling
23 | joinChannel | API Ref
24 | createCameraVideoTrack | API REf
25 | createClient | API Ref
26 | notification | Weird, it is in the call quality doc, but we go to the 3.x first
27 | user-published | Can we force to th eILS get started
28 | screen sharing | Screen sharing doc
29 | echo | Can we force to call quality?
30 | firewall | Should go to Firewall Doc
