### PR TITLE
856 flutter screenshare for ios android

### DIFF
--- a/shared/common/prerequities.mdx
+++ b/shared/common/prerequities.mdx
@@ -30,6 +30,7 @@
 - If your target platform is iOS:
   - Xcode on macOS (latest version recommended)
   - A physical iOS device
+  - iOS version 12.0 or later
 
 - If your target platform is Android:
   - Android Studio on macOS or Windows (latest version recommended)

--- a/shared/video-sdk/develop/_product-workflow.mdx
+++ b/shared/video-sdk/develop/_product-workflow.mdx
@@ -72,6 +72,8 @@ This page shows you how to add the following features to your <Vpl k="CLIENT" />
 
 In order to follow this procedure you must have implemented <Link to="../get-started/get-started-sdk">Get Started with <Vpd k="NAME"/></Link>.
 
+<Prerequites />
+
 ## Project setup
 
 To create the environment necessary to implement call quality best practice into your <Vpl k="CLIENT" />, open the project you created in <Link to="../get-started/get-started-sdk">Get Started with <Vpd k="NAME"/></Link>.

--- a/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
@@ -25,9 +25,9 @@ Row(
     ],
 ),
 ElevatedButton(
+    onPressed: _isJoined ? () => {shareScreen()} : null,
     child: Text(
         _isScreenShared ? "Stop sharing screen" : "Share screen"),
-    onPressed: () => {shareScreen()},
 ),
 ```
 
@@ -101,17 +101,6 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
     * **Windows**
 
         ```dart
-        agoraEngine.startScreenCaptureByScreenRect(
-            screenRect:  const Rectangle(x:0,y:0, width:640, height:400),
-            regionRect:  const Rectangle(),
-            captureParams: const ScreenCaptureParameters(
-                captureMouseCursor: true,
-                frameRate: 30,
-            )
-        );    
-        ```
-
-        ```dart
         // Get the list of available windows and displays
         List<ScreenCaptureSourceInfo> screenCaptureSourceList;
         screenCaptureSourceList = await agoraEngine.getScreenCaptureSources(
@@ -119,10 +108,11 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
             iconSize: const SIZE(width: 360, height: 240),
             includeScreen: false);
 
-        // Get the Id of the first item in the list
-        int? sourceId = screenCaptureSourceList.first.sourceId ?? 0;
+        // Get the Id of the last item in the list.
+        // In a real-life app, you list the sources and let the user choose.
+        int? sourceId = screenCaptureSourceList.last.sourceId ?? 0;
 
-        if (screenCaptureSourceList.first.type == ScreenCaptureSourceType.screencapturesourcetypeScreen) {
+        if (screenCaptureSourceList.last.type == ScreenCaptureSourceType.screencapturesourcetypeScreen) {
             // The source is a display
             agoraEngine.startScreenCaptureByDisplayId(
                 displayId: sourceId,
@@ -156,9 +146,11 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
                 frameRate: 15,
                 bitrate: 600)));  
         ```
-        :warning: **Note**: On **iOS**, screen sharing is only available on version 12.0 and later.
+        :warning: **Note**: 
+        
+        * On **iOS**, screen sharing is only available on version 12.0 and later.
 
-        On **Android**, your app must run as a foreground service so that it is not killed when minimized. To get the required permission, in `\android\app\src\main\AndroidManifest.xml`, add the following line after `</application>`.
+        * On **Android**, your app must run as a foreground service so that it is not killed when minimized. To add the `FOREGROUND_SERVICE` permission, in `\android\app\src\main\AndroidManifest.xml`, add the following line after `</application>`.
 
         ```xml
         <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>

--- a/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
@@ -82,7 +82,7 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
                 await agoraEngine.stopScreenCapture();
             }
 
-            // Update channel media options to publish camera or screenSharing streams
+            // Update channel media options to publish camera or screen capture streams
             ChannelMediaOptions options = ChannelMediaOptions(
                 publishCameraTrack: !_isScreenShared,
                 publishMicrophoneTrack: !_isScreenShared,
@@ -96,24 +96,27 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
         ```
 1. **Call the method to start screen sharing**
 
-    Depending on your target platform, you call a suitable <Vpd k="SDK" /> method to start screen sharing. Copy the code for your target platform and add it to `shareScreen()` after `// Start screen sharing`:
+    Depending on your target platform, you call a suitable <Vpd k="SDK" /> method to start screen sharing when the button is pressed. Copy the code for your target platform and add it to `shareScreen()` after `// Start screen sharing`:
 
-    * **Windows**
+    * **Windows and macOS**
+
+        On multi-window system, you obtain a list of available windows and displays and choose the source to share.
 
         ```dart
-        // Get the list of available windows and displays
+        // Get the list of available windows and displays.
         List<ScreenCaptureSourceInfo> screenCaptureSourceList;
         screenCaptureSourceList = await agoraEngine.getScreenCaptureSources(
             thumbSize: const SIZE(width: 360, height: 240),
             iconSize: const SIZE(width: 360, height: 240),
             includeScreen: false);
 
-        // Get the Id of the last item in the list.
         // In a real-life app, you list the sources and let the user choose.
+        // For this demo, get the Id of the last item in the list.
         int? sourceId = screenCaptureSourceList.last.sourceId ?? 0;
 
+        // Share the entire screen or a particular window.
         if (screenCaptureSourceList.last.type == ScreenCaptureSourceType.screencapturesourcetypeScreen) {
-            // The source is a display
+            // The source is a screen
             agoraEngine.startScreenCaptureByDisplayId(
                 displayId: sourceId,
                 regionRect: const Rectangle(),
@@ -135,6 +138,8 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
 
     * **iOS and Android**
 
+        On iOS and Android, you share the entire screen using the following method:
+
         ```dart
         agoraEngine.startScreenCapture(const ScreenCaptureParameters2(
             captureAudio: true,
@@ -146,19 +151,20 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
                 frameRate: 15,
                 bitrate: 600)));  
         ```
+        
         :warning: **Note**: 
         
-        * On **iOS**, screen sharing is only available on version 12.0 and later.
+        * **iOS**: Screen sharing is only available on iOS version 12.0 and later.
 
-        * On **Android**, your app must run as a foreground service so that it is not killed when minimized. To add the `FOREGROUND_SERVICE` permission, in `\android\app\src\main\AndroidManifest.xml`, add the following line after `</application>`.
+        * **Android**: Your app must run as a foreground service so that it is not killed when minimized. To add the `FOREGROUND_SERVICE` permission, in `\android\app\src\main\AndroidManifest.xml`, add the following line after `</application>`.
 
-        ```xml
-        <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-        ```
+            ```xml
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+            ```
 
 1. **Show screen sharing preview**
 
-    When a user starts screen sharing, the <Vpl k="CLIENT" /> switches to showing screen preview in the local video container. To do this, you update the code in the `_localPreview` widget. In `_MyAppState_` class, **replace** the `_localPreview` method with the following:
+    When a user starts screen sharing, your <Vpl k="CLIENT" /> switches to showing screen preview in the local video container. To do this, you update the `_localPreview` widget. In `_MyAppState_` class, **replace** the `_localPreview` method with the following:
 
     ```dart
     Widget _localPreview() {
@@ -174,17 +180,18 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
             } else {
                 return AgoraVideoView(
                     controller: VideoViewController(
-                    rtcEngine: agoraEngine,
-                    canvas: const VideoCanvas(
-                        uid: 0,
-                        sourceType: VideoSourceType.videoSourceScreen,
-                    ),
-                    ));
-            }   
+                rtcEngine: agoraEngine,
+                canvas: const VideoCanvas(
+                    uid: 0,
+                    sourceType: VideoSourceType.videoSourceScreen,
+                ),
+                ));
+            }
         } else {
-            return const Text('Join a channel', 
+            return const Text(
+                'Join a channel',
                 textAlign: TextAlign.center,
-        );
+            );
         }
     }
     ```

--- a/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
@@ -100,7 +100,7 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
 
     * **Windows and macOS**
 
-        On multi-window system, you obtain a list of available windows and displays and choose the source to share.
+        On a multi-window system, you obtain a list of available windows and displays and choose the source to share.
 
         ```dart
         // Get the list of available windows and displays.
@@ -111,7 +111,7 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
             includeScreen: false);
 
         // In a real-life app, you list the sources and let the user choose.
-        // For this demo, get the Id of the last item in the list.
+        // For this demo, get the sourceId of the last item in the list.
         int? sourceId = screenCaptureSourceList.last.sourceId ?? 0;
 
         // Share the entire screen or a particular window.
@@ -150,17 +150,7 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
                 dimensions: VideoDimensions(height: 1280, width: 720),
                 frameRate: 15,
                 bitrate: 600)));  
-        ```
-        
-        :warning: **Note**: 
-        
-        * **iOS**: Screen sharing is only available on iOS version 12.0 and later.
-
-        * **Android**: Your app must run as a foreground service so that it is not killed when minimized. To add the `FOREGROUND_SERVICE` permission, in `\android\app\src\main\AndroidManifest.xml`, add the following line after `</application>`.
-
-            ```xml
-            <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-            ```
+        ```  
 
 1. **Show screen sharing preview**
 

--- a/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
@@ -69,40 +69,66 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
 
     When a user presses the screen sharing button, you call a method to start screen sharing. When the user presses the button again, you call the method to stop screen capture. To do this, add the following method to the `_MyAppState` class:
 
-    ```dart
-    Future<void> shareScreen() async {
-        setState(() {
-        _isScreenShared = !_isScreenShared;
-        });
+        ```dart
+        Future<void> shareScreen() async {
+            setState(() {
+            _isScreenShared = !_isScreenShared;
+            });
 
-        if (_isScreenShared) {
-            agoraEngine.startScreenCaptureByScreenRect(
-                screenRect:  const Rectangle(x:0,y:0, width:640, height:400),
-                regionRect:  const Rectangle(),
-                captureParams: const ScreenCaptureParameters(
-                    captureMouseCursor: true,
-                    frameRate: 30,
-                )
+            if (_isScreenShared) {
+                // Start screen sharing
+
+            } else {
+                await agoraEngine.stopScreenCapture();
+            }
+
+            // Set and update channel media options
+            ChannelMediaOptions options = ChannelMediaOptions(
+                publishCameraTrack: !_isScreenShared,
+                publishMicrophoneTrack: !_isScreenShared,
+                publishScreenCaptureAudio: _isScreenShared,
+                publishScreenCaptureVideo: _isScreenShared,
             );
-        } else {
-            await agoraEngine.stopScreenCapture();
+
+            agoraEngine.updateChannelMediaOptions(options);
         }
+        ```
+1. **Call the method to start screen sharing**
 
-        // Set and update channel media options
-        ChannelMediaOptions options = ChannelMediaOptions(
-            publishScreenTrack: _isScreenShared,
-            publishCameraTrack: !_isScreenShared,
-        );
+    Depending on your target platform, you call a suitable <Vpd k="SDK" /> method to start screen sharing. Copy the code for your target platform and paste it in `shareScreen()` after `// Start screen sharing`:
 
-        agoraEngine.updateChannelMediaOptions(options);
-    }
-    ```
+    * Windows
 
-    ---
-    **Note**
+        ```dart
+        agoraEngine.startScreenCaptureByScreenRect(
+            screenRect:  const Rectangle(x:0,y:0, width:640, height:400),
+            regionRect:  const Rectangle(),
+            captureParams: const ScreenCaptureParameters(
+                captureMouseCursor: true,
+                frameRate: 30,
+            )
+        );    
+        ```
 
-    The Flutter screen sharing methods used in this example currently work only on the Windows platform. You need a custom implementation to enable screen sharing on other platforms.
-    ---
+    * iOS and Android
+
+        ```dart
+        agoraEngine.startScreenCapture(const ScreenCaptureParameters2(
+            captureAudio: true,
+            audioParams: ScreenAudioParameters(
+                sampleRate: 16000, channels: 2, captureSignalVolume: 100),
+            captureVideo: true,
+            videoParams: ScreenVideoParameters(
+                dimensions: VideoDimensions(height: 1280, width: 720),
+                frameRate: 15,
+                bitrate: 600)));  
+        ```
+
+        On **Android**, your app must run as a foreground service so that it is not killed when it is minimized. To get the required permission, in `\android\app\src\main\AndroidManifest.xml`, add the following line after `</application>`.
+
+        ```xml
+        <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+        ```
 
 1. **Show screen sharing preview**
 

--- a/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-implementation/flutter.mdx
@@ -82,10 +82,11 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
                 await agoraEngine.stopScreenCapture();
             }
 
-            // Set and update channel media options
+            // Update channel media options to publish camera or screenSharing streams
             ChannelMediaOptions options = ChannelMediaOptions(
                 publishCameraTrack: !_isScreenShared,
                 publishMicrophoneTrack: !_isScreenShared,
+                publishScreenTrack: _isScreenShared,
                 publishScreenCaptureAudio: _isScreenShared,
                 publishScreenCaptureVideo: _isScreenShared,
             );
@@ -95,9 +96,9 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
         ```
 1. **Call the method to start screen sharing**
 
-    Depending on your target platform, you call a suitable <Vpd k="SDK" /> method to start screen sharing. Copy the code for your target platform and paste it in `shareScreen()` after `// Start screen sharing`:
+    Depending on your target platform, you call a suitable <Vpd k="SDK" /> method to start screen sharing. Copy the code for your target platform and add it to `shareScreen()` after `// Start screen sharing`:
 
-    * Windows
+    * **Windows**
 
         ```dart
         agoraEngine.startScreenCaptureByScreenRect(
@@ -110,7 +111,39 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
         );    
         ```
 
-    * iOS and Android
+        ```dart
+        // Get the list of available windows and displays
+        List<ScreenCaptureSourceInfo> screenCaptureSourceList;
+        screenCaptureSourceList = await agoraEngine.getScreenCaptureSources(
+            thumbSize: const SIZE(width: 360, height: 240),
+            iconSize: const SIZE(width: 360, height: 240),
+            includeScreen: false);
+
+        // Get the Id of the first item in the list
+        int? sourceId = screenCaptureSourceList.first.sourceId ?? 0;
+
+        if (screenCaptureSourceList.first.type == ScreenCaptureSourceType.screencapturesourcetypeScreen) {
+            // The source is a display
+            agoraEngine.startScreenCaptureByDisplayId(
+                displayId: sourceId,
+                regionRect: const Rectangle(),
+                captureParams: const ScreenCaptureParameters(
+                captureMouseCursor: true,
+                frameRate: 30,
+                ));
+        } else { 
+            // The source is a window
+            agoraEngine.startScreenCaptureByWindowId(
+                windowId: sourceId,
+                regionRect: const Rectangle(),
+                captureParams: const ScreenCaptureParameters(
+                captureMouseCursor: true,
+                frameRate: 30,
+                ));
+        }        
+        ```
+
+    * **iOS and Android**
 
         ```dart
         agoraEngine.startScreenCapture(const ScreenCaptureParameters2(
@@ -123,8 +156,9 @@ To implement these features in your <Vpl k="CLIENT" />, take the following steps
                 frameRate: 15,
                 bitrate: 600)));  
         ```
+        :warning: **Note**: On **iOS**, screen sharing is only available on version 12.0 and later.
 
-        On **Android**, your app must run as a foreground service so that it is not killed when it is minimized. To get the required permission, in `\android\app\src\main\AndroidManifest.xml`, add the following line after `</application>`.
+        On **Android**, your app must run as a foreground service so that it is not killed when minimized. To get the required permission, in `\android\app\src\main\AndroidManifest.xml`, add the following line after `</application>`.
 
         ```xml
         <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>

--- a/shared/video-sdk/develop/product-workflow/project-setup/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-setup/flutter.mdx
@@ -1,3 +1,9 @@
 <PlatformWrapper platform="flutter">
 
+If your target platform is Android, your app must run as a foreground service so that it is not killed when minimized. To add the `FOREGROUND_SERVICE` permission, in `\android\app\src\main\AndroidManifest.xml`, add the following line after `</application>`.
+
+    ```xml
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    ```
+
 </PlatformWrapper>

--- a/shared/video-sdk/develop/product-workflow/project-test/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-test/flutter.mdx
@@ -45,11 +45,11 @@
 
 6. **Test Screen sharing**
 
-    1. To build your app for the Windows platform, execute `flutter build windows` in a terminal window. A `build` directory is created in your project folder that contains a Visual Studio solution. 
+    1. Press **Start Screen Sharing**. 
     
-    1. Open and [Compile the solution using Visual Studio](https://docs.flutter.dev/development/platform-integration/windows/building#compiling-with-visual-studio) and run the app.
-    
-    1. After you join a channel, press **Start Screen Sharing**. You see your Windows screen in the web demo app and in the local video container.
+        * On Windows, you see one of the open windows displayed in the local video container and in the web demo app.
+
+        * On iOS and Android, you see the entire screen displayed in the local video container and in the web demo app.
 
     1. Press **Stop Screen Sharing**. Screen sharing stops and the camera stream is restored.
 

--- a/shared/video-sdk/develop/product-workflow/project-test/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/project-test/flutter.mdx
@@ -47,10 +47,10 @@
 
     1. Press **Start Screen Sharing**. 
     
-        * On Windows, you see one of the open windows displayed in the local video container and in the web demo app.
+        * On Windows and macOS, you see one of the open windows displayed in the local video container and in the web demo app.
 
         * On iOS and Android, you see the entire screen displayed in the local video container and in the web demo app.
 
-    1. Press **Stop Screen Sharing**. Screen sharing stops and the camera stream is restored.
+    1. Press **Stop Screen Sharing**. Screen sharing stops and the camera video and audio streams are restored.
 
 </PlatformWrapper>

--- a/shared/video-sdk/develop/product-workflow/reference/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/reference/flutter.mdx
@@ -6,8 +6,6 @@
 
 - <Link to="{{Global.API_REF_FLUTTER_ROOT}}/class_irtcengine.html#api_irtcengine_startscreencapture">startScreenCapture</Link>
 
-- <Link to="{{Global.API_REF_FLUTTER_ROOT}}/class_irtcengine.html#api_irtcengine_startscreencapturebyscreenrect">startScreenCaptureByScreenRect</Link>
-
 - <Link to="{{Global.API_REF_FLUTTER_ROOT}}/class_irtcengine.html#api_irtcengine_startscreencapturebydisplayid">startScreenCaptureByDisplayId</Link>
 
 - <Link to="{{Global.API_REF_FLUTTER_ROOT}}/class_irtcengine.html#api_irtcengine_startscreencapturebywindowid">startScreenCaptureByWindowId</Link>

--- a/shared/video-sdk/develop/product-workflow/reference/flutter.mdx
+++ b/shared/video-sdk/develop/product-workflow/reference/flutter.mdx
@@ -2,6 +2,8 @@
 
 ### API reference
 
+- <Link to="{{Global.API_REF_FLUTTER_ROOT}}/class_irtcengine.html#api_irtcengine_getscreencapturesources">getScreenCaptureSources</Link>
+
 - <Link to="{{Global.API_REF_FLUTTER_ROOT}}/class_irtcengine.html#api_irtcengine_startscreencapture">startScreenCapture</Link>
 
 - <Link to="{{Global.API_REF_FLUTTER_ROOT}}/class_irtcengine.html#api_irtcengine_startscreencapturebyscreenrect">startScreenCaptureByScreenRect</Link>


### PR DESCRIPTION
Updated the Flutter doc to add screen sharing on iOS, Android, and macOS.

I also updated the Windows implementation to avoid using the deprecated `startScreenCaptureByScreenRect` method.

closes #856 