### PR TITLE
Add missing platform wrapper to unity doc

### DIFF
--- a/shared/voice-sdk/_authentication-workflow.mdx
+++ b/shared/voice-sdk/_authentication-workflow.mdx
@@ -107,7 +107,7 @@ To see how to create a token generator inside your IAM system, see [Integrate a 
 ### Retrieve and use tokens from a token server
 
 To integrate authentication into your <Vpl k="CLIENT" />:
-{ <ProjectImplement /> }
+<ProjectImplement />
 
 
 ## Test your implementation

--- a/shared/voice-sdk/authentication-workflow/project-implementation/index.mdx
+++ b/shared/voice-sdk/authentication-workflow/project-implementation/index.mdx
@@ -1,9 +1,9 @@
 import Android from './android.mdx';
 import Unity from './unity.mdx';
 import Flutter from './flutter.mdx';
-import ReactNative from './react-native.mdx'
-import Electron from './electron.mdx'
-import Web from './web.mdx'
+import ReactNative from './react-native.mdx';
+import Electron from './electron.mdx';
+import Web from './web.mdx';
 
 
 <Android />

--- a/shared/voice-sdk/authentication-workflow/project-implementation/unity.mdx
+++ b/shared/voice-sdk/authentication-workflow/project-implementation/unity.mdx
@@ -1,3 +1,5 @@
+<PlatformWrapper platform="unity">
+
 1. **Enable the user to specify a channel**
 
     Add a text box to the user interface.
@@ -136,3 +138,4 @@
     StartCoroutine(FetchToken(serverUrl, CHANNEL , uid, ExpireTime, this.FetchRenew));
     ```
 
+</PlatformWrapper>


### PR DESCRIPTION
- Resolves #1196 

The unity doc at `docs\shared\voice-sdk\authentication-workflow\project-implementation\unity.mdx` had no platform wrapper. Therefore it was appearing in all platforms, not just react-native. This PR fixes it.