### PR TITLE
Remove beta from vp9-codec-beta in release notes

### DIFF
--- a/shared/video-sdk/reference/release-notes/web.mdx
+++ b/shared/video-sdk/reference/release-notes/web.mdx
@@ -22,7 +22,7 @@ v4.19.2 was released on October 20, 2023.
 This release advances VP9 from Beta to General Availability (GA) and introduces the following enhancements:
 
 - Updated browser compatibility: VP9 now supports Safari 16.0 and later versions on both desktop and mobile platforms.
-- Automatic fallback to VP8 for older browsers: If any user in a channel uses a browser version below the [specified compatibility threshold](#vp9-codec-beta), all VP9-encoded video streams in that channel will automatically transition to VP8.
+- Automatic fallback to VP8 for older browsers: If any user in a channel uses a browser version below the [specified compatibility threshold](#vp9-codec), all VP9-encoded video streams in that channel will automatically transition to VP8.
 
 Test results show that VP9 provides twice the quality of VP8 at equivalent bitrates.
 


### PR DESCRIPTION
The link:

https://docs.agora.io/en/video-calling/reference/release-notes?platform=web#vp9-codec-beta

has the incorrect URI fragment. it should be:

https://docs.agora.io/en/video-calling/reference/release-notes?platform=web#vp9-codec